### PR TITLE
Update sha256 for new Ruby installer

### DIFF
--- a/installer.run.sha256
+++ b/installer.run.sha256
@@ -1,1 +1,1 @@
-b21ee4cd60eea6e516473cf33d5f2c3a1c30c27c953c3021be6b9d0cabb77707  /tmp/installer.run
+7c7e32bc83a73097386141d5ad3be7393e8bccc948cf922bb37e8c01e36d8404  /tmp/installer.run


### PR DESCRIPTION
Old ruby installer was faulty, update the sha256 to match with the new installer