### PR TITLE
ruby: initialize `ruby` module at build time

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 # System packages required
 RUN install_packages libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libpq5
 
-RUN bitnami-pkg unpack ruby-2.1.10-4 --checksum 205f8f287dec90b00d41cc3399280276a950ac4139c2937f97d937f6aca94630
+RUN bitnami-pkg install ruby-2.1.10-4 --checksum 205f8f287dec90b00d41cc3399280276a950ac4139c2937f97d937f6aca94630
 
 COPY rootfs /
 

--- a/2.1/rootfs/app-entrypoint.sh
+++ b/2.1/rootfs/app-entrypoint.sh
@@ -5,6 +5,6 @@
 print_welcome_page
 check_for_updates &
 
-nami_initialize ruby
+log "ruby successfully initialized"
 
 exec tini -- "$@"

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 # System packages required
 RUN install_packages libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libpq5
 
-RUN bitnami-pkg unpack ruby-2.2.6-2 --checksum be1e9359fcbe2e70742a79fe270537932a62833bec67d0c7ba6a0b505dcd35ce
+RUN bitnami-pkg install ruby-2.2.6-2 --checksum be1e9359fcbe2e70742a79fe270537932a62833bec67d0c7ba6a0b505dcd35ce
 
 COPY rootfs /
 

--- a/2.2/rootfs/app-entrypoint.sh
+++ b/2.2/rootfs/app-entrypoint.sh
@@ -5,6 +5,6 @@
 print_welcome_page
 check_for_updates &
 
-nami_initialize ruby
+log "ruby successfully initialized"
 
 exec tini -- "$@"

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 # System packages required
 RUN install_packages libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libpq5
 
-RUN bitnami-pkg unpack ruby-2.3.3-2 --checksum 8c1533927a9cfb3b1dfb6cbd3e24c33d1f670f104e6d4c1942776525db9e4729
+RUN bitnami-pkg install ruby-2.3.3-2 --checksum 8c1533927a9cfb3b1dfb6cbd3e24c33d1f670f104e6d4c1942776525db9e4729
 
 COPY rootfs /
 

--- a/2.3/rootfs/app-entrypoint.sh
+++ b/2.3/rootfs/app-entrypoint.sh
@@ -5,6 +5,6 @@
 print_welcome_page
 check_for_updates &
 
-nami_initialize ruby
+log "ruby successfully initialized"
 
 exec tini -- "$@"

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 # System packages required
 RUN install_packages libc6 libssl1.0.0 zlib1g libreadline6 libncurses5 libtinfo5 libffi6 libxml2-dev zlib1g-dev libxslt1-dev libgmp-dev ghostscript imagemagick libmysqlclient18 libpq5
 
-RUN bitnami-pkg unpack ruby-2.4.0-1 --checksum c42ef6b39fe67b3fc60e41e42aa5d3a39de0f714069369a15342ceed0b53a6a5
+RUN bitnami-pkg install ruby-2.4.0-1 --checksum c42ef6b39fe67b3fc60e41e42aa5d3a39de0f714069369a15342ceed0b53a6a5
 
 COPY rootfs /
 

--- a/2.4/rootfs/app-entrypoint.sh
+++ b/2.4/rootfs/app-entrypoint.sh
@@ -5,6 +5,6 @@
 print_welcome_page
 check_for_updates &
 
-nami_initialize ruby
+log "ruby successfully initialized"
 
 exec tini -- "$@"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Performing `nami initialize ruby` at runtime negatively effects the container startup time.
This step is generally not needed and was added as a workaround for internal testing tools.

We still need a workaround for our internal testing tools and at this time the replacement 
`echo` statement achieves it.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Speeds up container launch

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->