### PR TITLE
example: fix ssl version in ruby-example

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -12,7 +12,7 @@ FROM bitnami/ruby:2.4-prod
 ENV RAILS_ENV="production" \
     SECRET_KEY_BASE="your_production_key" \
     RAILS_SERVE_STATIC_FILES="yes"
-RUN install_packages libssl1.0.0
+RUN install_packages libssl1.0.2
 COPY --from=builder /app /app
 WORKDIR /app
 EXPOSE 3000


### PR DESCRIPTION
fixes image builds on docker-hub, ref: https://hub.docker.com/r/bitnami/ruby-example/builds/beza4ip6jvxfhx2ra8vqber/